### PR TITLE
Updated package.json peerDependies to latest css-condense version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-cssc",
   "description": "css-condense grunt plugin",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "homepage": "https://github.com/mediapart/grunt-cssc",
   "author": {
     "name": "Étienne Samson",
@@ -32,15 +32,15 @@
     "grunt-contrib-clean": "~0.4.0",
     "grunt-contrib-nodeunit": "~0.1.2",
     "grunt-contrib-watch": "~0.3.1",
-    "css-condense": "~0.0.6",
+    "css-condense": "~0.1.1",
     "grunt": "~0.4.1"
   },
   "peerDependencies": {
     "grunt": "~0.4.1",
-    "css-condense": "~0.0.6"
+    "css-condense": "~0.1.1"
   },
   "dependencies": {
-    "css-condense": "~0.0.6"
+    "css-condense": "~0.1.1"
   },
   "keywords": [
     "gruntplugin"


### PR DESCRIPTION
As outlined [here](https://github.com/mediapart/grunt-cssc/issues/4#issuecomment-70172784) the outdated css-condense dependency which currently uses `v0.0.6` was updated to the latest version`v0.1.1`.